### PR TITLE
Add target option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ interface WebExtPluginOptions {
   keepProfileChanges?: boolean;
   profileCreateIfMissing?: boolean;
   startUrl?: string;
+  target?: 'firefox-desktop' | 'firefox-android' | 'chromium';
 }
 
 class WebExtPlugin {

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ class WebExtPlugin {
     keepProfileChanges,
     profileCreateIfMissing,
     startUrl,
+    target,
   } = {}) {
     this.runner = null;
     this.watchMode = false;
@@ -26,6 +27,7 @@ class WebExtPlugin {
     this.profileCreateIfMissing = profileCreateIfMissing;
     this.sourceDir = path.resolve(__dirname, sourceDir);
     this.startUrl = startUrl;
+    this.target = target;
   }
 
   apply(compiler) {
@@ -66,6 +68,7 @@ class WebExtPlugin {
               artifactsDir: this.artifactsDir,
               browserConsole: this.browserConsole,
               sourceDir: this.sourceDir,
+              target: this.target,
               firefox: this.firefox,
               firefoxProfile: this.firefoxProfile,
               keepProfileChanges: this.keepProfileChanges,


### PR DESCRIPTION
### Usage

**File:** `webpack.config.js`

```diff
const WebExtPlugin = require('web-ext-plugin');

module.exports = {
  plugins: [new WebExtPlugin({ 
    sourceDir: 'extension-dist',
+   target: 'chromium' 
  })],
};
```

### Docs

https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#global-options