### PR TITLE
Support for all android options

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ mode using `webpack -w`.
 These options only apply when `target` is set to `firefox-android`:
 
 - `adbDevice` (required) - Connect to the specified adb device name.
-- `adbBin` (optional) - Specify a custom path to the adb binary. Defaults to assuming `adb` execeutable in in `PATH`.
+- `adbBin` (optional) - Specify a custom path to the adb binary. Defaults to assuming `adb` executable is in `PATH`.
 - `adbHost` (optional) - Connect to adb on the specified host. Defaults to being discovered automatically.
 - `adbPort` (optional) - A string that specifies the port adb will connect to. Defaults to being discovered automatically.
 - `adbDiscoveryTimeout` (optional) - Number of milliseconds to wait before giving up. Defaults to `180000` (3 minutes).
-- `adbRemoveOldArtifacts` (optional) - If `true` it will always remove old artifacts files from the adb device when it does exit. Defaults to `false`.
+- `adbRemoveOldArtifacts` (optional) - If `true` it will always remove old artifacts files from the adb device when it exits. Defaults to `false`.
 - `firefoxApk` (optional) - Run a specific Firefox for Android APK. Example: `org.mozilla.fennec_aurora`. If unspecified and there is only one available, it will be selected automatically.
 - `firefoxApkComponent` (optional) - Run a specific Android Component (defaults to `<firefox-apk>/.App`).

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ mode using `webpack -w`.
 
 ### Android-specific options
 
-These options only apply when `target` is set to `firefox-android`:
+These options only apply when `target` includes `firefox-android`:
 
 - `adbDevice` (required) - Connect to the specified adb device name.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ mode using `webpack -w`.
 - `firefoxProfile` (optional) - A specific Firefox profile to use.
   This may be either a profile name or the path to a profile directory.
   If this is not set a new profile is generated each time.
-
 - `keepProfileChanges` (optional) - A boolean value indicating if the profile
   specified by `firefoxProfile`.
 
@@ -136,10 +135,17 @@ mode using `webpack -w`.
 These options only apply when `target` is set to `firefox-android`:
 
 - `adbDevice` (required) - Connect to the specified adb device name.
+
 - `adbBin` (optional) - Specify a custom path to the adb binary. Defaults to assuming `adb` executable is in `PATH`.
+
 - `adbHost` (optional) - Connect to adb on the specified host. Defaults to being discovered automatically.
+
 - `adbPort` (optional) - A string that specifies the port adb will connect to. Defaults to being discovered automatically.
+
 - `adbDiscoveryTimeout` (optional) - Number of milliseconds to wait before giving up. Defaults to `180000` (3 minutes).
+
 - `adbRemoveOldArtifacts` (optional) - If `true` it will always remove old artifacts files from the adb device when it exits. Defaults to `false`.
+
 - `firefoxApk` (optional) - Run a specific Firefox for Android APK. Example: `org.mozilla.fennec_aurora`. If unspecified and there is only one available, it will be selected automatically.
+
 - `firefoxApkComponent` (optional) - Run a specific Android Component (defaults to `<firefox-apk>/.App`).

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ mode using `webpack -w`.
 - `firefoxProfile` (optional) - A specific Firefox profile to use.
   This may be either a profile name or the path to a profile directory.
   If this is not set a new profile is generated each time.
+
 - `keepProfileChanges` (optional) - A boolean value indicating if the profile
   specified by `firefoxProfile`.
 
@@ -129,3 +130,16 @@ mode using `webpack -w`.
   Defaults to `firefox-desktop`.
 
   See the documentation for the `--target` option of [`web-ext run`](https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#web-ext-run).
+
+### Android-specific options
+
+These options only apply when `target` is set to `firefox-android`:
+
+- `adbDevice` (required) - Connect to the specified adb device name.
+- `adbBin` (optional) - Specify a custom path to the adb binary. Defaults to assuming `adb` execeutable in in `PATH`.
+- `adbHost` (optional) - Connect to adb on the specified host. Defaults to being discovered automatically.
+- `adbPort` (optional) - A string that specifies the port adb will connect to. Defaults to being discovered automatically.
+- `adbDiscoveryTimeout` (optional) - Number of milliseconds to wait before giving up. Defaults to `180000` (3 minutes).
+- `adbRemoveOldArtifacts` (optional) - If `true` it will always remove old artifacts files from the adb device when it does exit. Defaults to `false`.
+- `firefoxApk` (optional) - Run a specific Firefox for Android APK. Example: `org.mozilla.fennec_aurora`. If unspecified and there is only one available, it will be selected automatically.
+- `firefoxApkComponent` (optional) - Run a specific Android Component (defaults to `<firefox-apk>/.App`).

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,14 @@ export declare interface WebExtPluginOptions {
   sourceDir?: string;
   startUrl?: string | Array<string>;
   target?: TargetType | Array<TargetType>;
+  adbBin?: string;
+  adbHost?: string;
+  adbPort?: string;
+  adbDevice?: string;
+  adbDiscoveryTimeout?: number;
+  adbRemoveOldArtifacts?: boolean;
+  firefoxApk?: string;
+  firefoxApkComponent?: string;
 }
 
 export default class WebExtPlugin {

--- a/index.js
+++ b/index.js
@@ -27,6 +27,14 @@ export default class WebExtPlugin {
     selfHosted = false,
     startUrl,
     target,
+    adbBin,
+    adbHost,
+    adbPort,
+    adbDevice,
+    adbDiscoveryTimeout,
+    adbRemoveOldArtifacts,
+    firefoxApk,
+    firefoxApkComponent
   } = {}) {
     this.runner = null;
     this.watchMode = false;
@@ -48,6 +56,14 @@ export default class WebExtPlugin {
     this.sourceDir = path.resolve(__dirname, sourceDir);
     this.startUrl = startUrl;
     this.target = target;
+    this.adbBin = adbBin;
+    this.adbHost = adbHost;
+    this.adbPort = adbPort;
+    this.adbDevice = adbDevice;
+    this.adbDiscoveryTimeout = adbDiscoveryTimeout;
+    this.adbRemoveOldArtifacts = adbRemoveOldArtifacts;
+    this.firefoxApk = firefoxApk;
+    this.firefoxApkComponent = firefoxApkComponent;
   }
 
   apply(compiler) {
@@ -119,6 +135,14 @@ export default class WebExtPlugin {
             sourceDir: this.sourceDir,
             startUrl: this.startUrl,
             target: this.target,
+            adbBin: this.adbBin,
+            adbHost: this.adbHost,
+            adbPort: this.adbPort,
+            adbDevice: this.adbDevice,
+            adbDiscoveryTimeout: this.adbDiscoveryTimeout,
+            adbRemoveOldArtifacts: this.adbRemoveOldArtifacts,
+            firefoxApk: this.firefoxApk,
+            firefoxApkComponent: this.firefoxApkComponent
           },
           {}
         );


### PR DESCRIPTION
**Hello**,

In this pull request I add support for all android options. With these, it actually enables it to run on `firefox-android` target (as `adbDevice` is actually required and never selected automatically).

Thanks for your work 😀

_luskaner_