### PR TITLE
Changed firefoxPreview option from being an string to array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export declare interface WebExtPluginOptions {
   chromiumBinary?: string;
   chromiumProfile?: string;
   firefox?: string;
-  firefoxPreview?: 'mv3';
+  firefoxPreview?: ['mv3'];
   firefoxProfile?: string;
   keepProfileChanges?: boolean;
   outputFilename?: string;


### PR DESCRIPTION
Hello:

`firefoxPreview` option is set to be a string in the typing but in reality **it is a array** with a single possible value (so far) `mv3`. 
Nonetheless, it currently works the same `mv3` as `["mv3"]` by pure luck as `web-ext` checks `firefoxPreview.includes('mv3')` because both string and array objects such method (as can be seen [here](https://github.com/mozilla/web-ext/blob/7.2.0/src/cmd/run.js#L132))

_luskaner,_