### PR TITLE
Add noInput option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ mode using `webpack -w`.
   It is, however, useful if you want to force the profile in a specific location
   to be written to (e.g. for testing out-of-disk space situations).
 
+- `noInput` (optional) - If `true` disables all features that require standard
+  input.
+
+  Defaults to `true` in watch mode and `false` otherwise.
+
 - `outputFilename` (optional) - The name of the .zip file to write when
   `buildPackage` is true.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ export declare interface WebExtPluginOptions {
   firefoxProfile?: string;
   ignoreFiles?: Array<string>;
   keepProfileChanges?: boolean;
+  noInput?: boolean;
   outputFilename?: string;
   overwriteDest?: boolean;
   pref?: { [key: string]: boolean | string | number };

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ export default class WebExtPlugin {
     firefoxProfile,
     ignoreFiles = [],
     keepProfileChanges,
+    noInput,
     outputFilename,
     overwriteDest = false,
     pref,
@@ -53,6 +54,7 @@ export default class WebExtPlugin {
     this.firefoxProfile = firefoxProfile;
     this.ignoreFiles = ignoreFiles;
     this.keepProfileChanges = keepProfileChanges;
+    this.noInput = noInput;
     this.outputFilename = outputFilename;
     this.overwriteDest = overwriteDest;
     this.pref = pref;
@@ -143,6 +145,7 @@ export default class WebExtPlugin {
             firefoxProfile: this.firefoxProfile,
             ignoreFiles: this.ignoreFiles
             keepProfileChanges: this.keepProfileChanges,
+            noInput: this.noInput ?? !this.watchMode,
             noReload: true,
             pref: this.pref,
             profileCreateIfMissing: this.profileCreateIfMissing,


### PR DESCRIPTION
Hello:

This adds the `noInput` option equivalent to the global option `--no-input`. 
*Note: this option is only passed to the `run` function as currently is only used there even although is meant to be global in web-ext docs*

Currently, this option should not change the behaviour of the plugin. however in the future could be useful as normally you don't want any input if you are for example building the extension on your CI.

_luskaner,_