### PR TITLE
feat: added devtools option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ mode using `webpack -w`.
 
   Defaults to false.
 
+- `devtools` (optional) - A boolean indicating if DevTools
+  should be shown on load. Requires Firefox 106 and later.
+
+  Defaults to false.
+
 - `buildPackage` (optional) - A boolean indicating if a zip file of the
   extension should be generated.
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,6 @@ mode using `webpack -w`.
 
   Defaults to false.
 
-- `devtools` (optional) - A boolean indicating if DevTools
-  should be shown on load. Requires Firefox 106 and later.
-
-  Defaults to false.
-
 - `buildPackage` (optional) - A boolean indicating if a zip file of the
   extension should be generated.
 
@@ -60,6 +55,11 @@ mode using `webpack -w`.
   alias string.
 
 - `chromiumProfile` (optional) - A path to a custom Chromium profile to use.
+
+- `devtools` (optional) - A boolean indicating if DevTools
+  should be shown on load. Requires Firefox 106 and later.
+
+  Defaults to false.
 
 - `firefox` (optional) - A path to a specific version of Firefox to run.
   The value is an absolute path to the Firefox executable or an alias string.

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,10 +6,10 @@ export declare interface WebExtPluginOptions {
   args?: Array<string>;
   artifactsDir?: string;
   browserConsole?: boolean;
-  devtools?: boolean;
   buildPackage?: boolean;
   chromiumBinary?: string;
   chromiumProfile?: string;
+  devtools?: boolean;
   firefox?: string;
   firefoxPreview?: ['mv3'];
   firefoxProfile?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ export declare interface WebExtPluginOptions {
   args?: Array<string>;
   artifactsDir?: string;
   browserConsole?: boolean;
+  devtools?: boolean;
   buildPackage?: boolean;
   chromiumBinary?: string;
   chromiumProfile?: string;

--- a/index.js
+++ b/index.js
@@ -14,10 +14,10 @@ export default class WebExtPlugin {
     args,
     artifactsDir = path.join(sourceDir, 'web-ext-artifacts'),
     browserConsole = false,
-    devtools = false,
     buildPackage = false,
     chromiumBinary,
     chromiumProfile,
+    devtools = false,
     firefox,
     firefoxPreview,
     firefoxProfile,
@@ -48,10 +48,10 @@ export default class WebExtPlugin {
     this.args = args;
     this.artifactsDir = artifactsDir;
     this.browserConsole = browserConsole;
-    this.devtools = devtools;
     this.buildPackage = buildPackage;
     this.chromiumBinary = chromiumBinary;
     this.chromiumProfile = chromiumProfile;
+    this.devtools = devtools;
     this.firefox = firefox;
     this.firefoxPreview = firefoxPreview;
     this.firefoxProfile = firefoxProfile;
@@ -142,9 +142,9 @@ export default class WebExtPlugin {
             args: this.args,
             artifactsDir: this.artifactsDir,
             browserConsole: this.browserConsole,
-            devtools: this.devtools,
             chromiumBinary: this.chromiumBinary,
             chromiumProfile: this.chromiumProfile,
+            devtools: this.devtools,
             firefox: this.firefox,
             firefoxPreview: this.firefoxPreview,
             firefoxProfile: this.firefoxProfile,

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ export default class WebExtPlugin {
     args,
     artifactsDir = path.join(sourceDir, 'web-ext-artifacts'),
     browserConsole = false,
+    devtools = false,
     buildPackage = false,
     chromiumBinary,
     chromiumProfile,
@@ -47,6 +48,7 @@ export default class WebExtPlugin {
     this.args = args;
     this.artifactsDir = artifactsDir;
     this.browserConsole = browserConsole;
+    this.devtools = devtools;
     this.buildPackage = buildPackage;
     this.chromiumBinary = chromiumBinary;
     this.chromiumProfile = chromiumProfile;
@@ -140,6 +142,7 @@ export default class WebExtPlugin {
             args: this.args,
             artifactsDir: this.artifactsDir,
             browserConsole: this.browserConsole,
+            devtools: this.devtools,
             chromiumBinary: this.chromiumBinary,
             chromiumProfile: this.chromiumProfile,
             firefox: this.firefox,


### PR DESCRIPTION
Hello:

As of [web-ext 7.3.0](https://github.com/mozilla/web-ext/releases/tag/7.3.0) a new option `devtools` was added, so this adds it too.