### PR TITLE
add options for ignoring specific lints

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ mode using `webpack -w`.
   If multiple fields are present in the object, they will be treated as an "and" condition, allowing specific errors to be ignored.
   Only applies if `runLint` is true.
 
-  Defaults to false.
+  Defaults to [] (empty array).
 
 - `selfHosted` (optional) - If `true` declares that your extension will be
   self-hosted and disables lint messages related to hosting on

--- a/README.md
+++ b/README.md
@@ -143,6 +143,24 @@ mode using `webpack -w`.
 
   Defaults to false.
 
+- `ignoreKnownChromeLintFailures` (optional) - A boolean indicating whether lint errors known to fail when trying to check a chrome extension should be ignored. Only applies if `runLint` is true.
+
+  Defaults to false.
+
+- `filterLintFailures` (optional) - An array of objects that will be used to selectively ignore lint errors that match. An example of these objects looks like this:
+  ```
+  {
+    code?: string;
+    message?: string;
+    file?: string;
+  }
+  ```
+  If any of the fields are present, they will be matched against linter errors found and will be used to remove them.
+  If multiple fields are present in the object, they will be treated as an "and" condition, allowing specific errors to be ignored.
+  Only applies if `runLint` is true.
+
+  Defaults to false.
+
 - `selfHosted` (optional) - If `true` declares that your extension will be
   self-hosted and disables lint messages related to hosting on
   addons.mozilla.org.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,12 @@ import { Compiler } from 'webpack';
 
 export type TargetType = 'firefox-desktop' | 'firefox-android' | 'chromium';
 
+export type LintMatcher = {
+  code?: string;
+  message?: string;
+  file?: string;
+}
+
 export declare interface WebExtPluginOptions {
   args?: Array<string>;
   artifactsDir?: string;
@@ -22,6 +28,8 @@ export declare interface WebExtPluginOptions {
   profileCreateIfMissing?: boolean;
   runLint?: boolean;
   lintWarningsAsErrors?: boolean;
+  ignoreKnownChromeLintFailures?:boolean;
+  filterLintFailures?: Array<LintMatcher>;
   selfHosted?: boolean;
   sourceDir?: string;
   startUrl?: string | Array<string>;

--- a/index.js
+++ b/index.js
@@ -124,8 +124,16 @@ export default class WebExtPlugin {
           }
           return true;
         }
+
+        if (this.ignoreKnownChromeLintFailures) {
+          //add known failures caused by differences in chrome and firefox manifests
+          this.filterLintFailures.push({
+            code: "MANIFEST_FIELD_UNSUPPORTED",
+            message: '"/background" is in an unsupported format.'
+          });
+        }
         
-        if (this.filterLintFailures || this.ignoreKnownChromeLintFailures) {
+        if (this.filterLintFailures) {
           for (const filter of this.filterLintFailures) {
             lintErrors = lintErrors.filter((value, index) =>
               !checkFilterMatch(filter, value)

--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ export default class WebExtPlugin {
         let lintSummary = result.summary
         let lintErrors = result.errors;
 
+        //if lintWarningsAsErrors is true include those values too
         if (this.lintWarningsAsErrors) {
           lintSummary.errors += lintSummary.warnings;
           lintSummary.warnings = 0;
@@ -145,8 +146,6 @@ export default class WebExtPlugin {
         // Abort on any lint errors or warnings if lintWarningsAsErrors is true
         if (lintSummary.errors) {
           throw new Error(lintErrors[0].message);
-        } else if (this.lintWarningsAsErrors && lintSummary.warnings) {
-          throw new Error(result.warnings[0].message);
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -128,6 +128,8 @@ export default class WebExtPlugin {
 
         if (this.ignoreKnownChromeLintFailures) {
           //add known failures caused by differences in chrome and firefox manifests
+          
+          //https://github.com/mozilla/web-ext/issues/2532
           this.filterLintFailures.push({
             code: "MANIFEST_FIELD_UNSUPPORTED",
             message: '"/background" is in an unsupported format.'

--- a/index.js
+++ b/index.js
@@ -126,21 +126,11 @@ export default class WebExtPlugin {
         }
         
         if (this.filterLintFailures || this.ignoreKnownChromeLintFailures) {
-          for (const e of lintErrors) {
-            console.log(e)
-            for (const f of this.filterLintFailures) {
-              if (checkFilterMatch(f, e)){
-                //remove the error
-                console.log("removing ")
-                console.log(e)
-                let i = lintErrors.indexOf(e)
-                console.log(i)
-                lintErrors = lintErrors.splice(i, 1);
-                lintSummary.errors -= 1;
-              }
-            }
+          for (const filter of this.filterLintFailures) {
+            lintErrors = lintErrors.filter((value, index) =>
+              !checkFilterMatch(filter, value)
+            )
           }
-          console.log(lintErrors)
         }
 
 


### PR DESCRIPTION
fixes #67 

This adds two new flags in the constructor as documented (hopefully in a way that makes sense - may need rewording) in the README.

**Features:**

- this allows specific linter errors to be ignored by passing in an object containing some of the key properties that can identify an error (currently implemented: code, message, file). If all of the provided values match an error from the linter, that error is filtered out before deciding whether the program should raise an error or not.
- includes a shortcut (`ignoreKnownChromeLintFailures`) that ignore lint failures that are raised due to differences between firefox and chrome manifest formats (see https://github.com/mozilla/web-ext/issues/2532 for an example). This is not a mechanism that fullly supports validating chrome extensions, but it is a way to prevent this linter from failing when given a valid chrome extension
- plays nice with the existing `lintWarningsAsErrors`, allowing warnings to be filtered as well if this option is true

**Testing**:
Tested using the build scripts of a web extension I've been working on recently that uses this plugin. Output in most scenarios (such as with and without `lintWarningsAsErrors`, valid filters, invalid filters, and handling of junk data) seems to match what would reasonably be expected.

as an example:
```
filterLintFailures: [{
	code: "MANIFEST_FIELD_UNSUPPORTED",
	message: '"/background" is in an unsupported format.'
},
{
	code: "MANIFEST_FIELD_PPORTED",
	message: '"/background" is in an unsupported format.'
},{
	totally:"fake",
	data:"here"
}],
```
This sample data successfully filters the error indicated by the first rule, and essentially ignores the other two. This set of filters is (currently) the same as what `ignoreKnownChromeLintFailures` would add automatically.

**Changes to be made**:

- [ ] Bump version number (maybe? not sure what it should be set to)
- [ ] Automated testing would probably be a good idea to add given the number of combinations/branches of behavior involved here*

\* I would do this, but I'm skeptical that [the way I set up junit in a project recently](https://github.com/MoralCode/RIT-Rate-My-Professors-Extension/commit/bbf32e6f25c8948557a89123b41358fdc63b0d7c#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R7) may cause other things to break. maybe `vitest` as mentioned in the linked issue works differently?
