### PR TITLE
bugfix: update the count of lint errors when filtering the list

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,7 @@ export default class WebExtPlugin {
               !checkFilterMatch(filter, value)
             )
           }
+          lintSummary.errors = lintErrors.length
         }
 
 


### PR DESCRIPTION
Turns out there was a bug in my previous PR (#68) where i wasn't updating the error count after filtering the list.

This results in an error like this:
```
[webpack-cli] TypeError: Cannot read properties of undefined (reading 'message')
    at afterEmit (file:///home/ace/Projects/Current/RIT/RIT-Rate-My-Professors-Extension/node_modules/web-ext-plugin/index.js:150:41)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at runNextTicks (node:internal/process/task_queues:65:3)
    at processImmediate (node:internal/timers:444:9)
```
which is caused by `lintSummary.errors` having a nonzero value while `lintErrors` is an empty list. This causes problems with the line of code thats supposed to raise an error if there are any unfiltered lint errors:
```javascript
if (lintSummary.errors) {
  throw new Error(lintErrors[0].message);
}
```

This PR ensures that the summary count matches the actual length of the errors list.

A potentially better systematic solution to prevent potential regressions might be to just rely on the length of the errors list when performing this check.